### PR TITLE
Add app-ads.txt for the AdMob publisher account

### DIFF
--- a/.okf/log.md
+++ b/.okf/log.md
@@ -166,3 +166,22 @@
   output. A static asset cannot 500; an edge function can. See the comment in
   `components/products/meta.ts` for why the routes are concrete rather than
   `[slug]`.
+
+* **2026-07-30 — `app-ads.txt`.** `public/app-ads.txt` declares Cybiqon as an authorised
+  seller for AdMob publisher `pub-6927966479089034`, which Lumina's ads run under.
+
+  This is not paperwork. Buyers check the file against the developer website on an app's
+  store listing, and without it a large share of demand will not bid — a **silent revenue
+  loss rather than an error**. Nothing breaks; the money simply does not arrive, and
+  there is no signal anywhere that it is happening.
+
+  Deliberately plain ASCII: the file is machine-read by a long tail of crawlers, and an
+  em-dash in a comment is not worth discovering the hard way.
+
+  **It cannot validate yet.** AdMob verifies by crawling the developer website named on
+  the Play listing, and Lumina is not published. Once it is live, set the developer
+  website to `cybiqon.in` and link the AdMob app to the store listing — the file only
+  starts earning at that point.
+
+  Served from `public/`, like `favicon.ico`; verified that other files in that directory
+  reach the deployed static output and answer at the site root in production.

--- a/public/app-ads.txt
+++ b/public/app-ads.txt
@@ -1,0 +1,18 @@
+# app-ads.txt - authorised digital sellers for Cybiqon AI Solutions
+#
+# Declares which ad networks may sell inventory in our apps. Buyers check this
+# file against the developer website on an app's store listing; if it is missing,
+# or does not name the seller, a large share of demand will not bid. That is a
+# silent revenue loss rather than an error - nothing breaks, the money simply
+# does not arrive.
+#
+# Deliberately plain ASCII. This is machine-read by a long tail of crawlers, and
+# a stray em-dash in a comment is not worth finding out about the hard way.
+#
+# Format: <domain>, <publisher id>, <DIRECT|RESELLER>, <certification id>
+# Spec:   https://iabtechlab.com/ads-txt/
+#
+# The trailing id is Google's TAG certification authority id, identical for
+# every AdMob publisher. The line below is ours.
+
+google.com, pub-6927966479089034, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
Declares Cybiqon as an authorised seller for `pub-6927966479089034`, the AdMob account Lumina's ad units belong to.

**Why now, before the app is live:** the failure mode is invisible. Buyers check this file against the developer website on an app's store listing, and without it a large share of demand does not bid. Nothing errors, nothing logs — the revenue is simply lower than it should be, with no signal from inside the app.

```
google.com, pub-6927966479089034, DIRECT, f08c47fec0942fa0
```

### Verified rather than assumed

- The publisher id matches the AdMob app id in Lumina's `AndroidManifest.xml`
- Other files in `public/` (`favicon.ico`, `logo.png`) reach the deployed static output **and** answer 200 at the site root in production — so this will be served at `/app-ads.txt`
- `npm run build` clean

### Plain ASCII on purpose

The file is machine-read by a long tail of crawlers. A stray em-dash in a comment is not worth finding out about through a support thread six months from now.

### It cannot validate yet

AdMob crawls the developer website named on the Play listing, and Lumina is not published. Once it is, the listing's website has to be `cybiqon.in` and the AdMob app has to be linked to the store entry. Only then does this file start doing anything — having it ready now just removes a step from launch day.
